### PR TITLE
Accept secrets as a block/object

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cipher_secret"></a> [cipher\_secret](#input\_cipher\_secret) | External cipher secret to import and use instead of generating one, must be exactly 32 characters long | `string` | `null` | no |
 | <a name="input_config_files"></a> [config\_files](#input\_config\_files) | Additional files to be mounted at /etc/kratos, e.g. identity schemas and courier templates | `map(string)` | `{}` | no |
 | <a name="input_config_yaml"></a> [config\_yaml](#input\_config\_yaml) | Content of kratos.yaml configuration file | `string` | n/a | yes |
-| <a name="input_cookie_secret"></a> [cookie\_secret](#input\_cookie\_secret) | External cookie secret to import and use instead of generating one, must be at least 16 characters long | `string` | `null` | no |
 | <a name="input_courier_mode"></a> [courier\_mode](#input\_courier\_mode) | Message courier deployment mode, one of: "disabled", "background", "standalone" | `string` | n/a | yes |
 | <a name="input_courier_resources"></a> [courier\_resources](#input\_courier\_resources) | Resource requests and limits for courier Kratos pod | <pre>object({<br/>    requests = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>    limits = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_courier_smtp_connection_uri"></a> [courier\_smtp\_connection\_uri](#input\_courier\_smtp\_connection\_uri) | SMTP connection data and credentials in URI form for email delivery, e.g. smtps://apikey:SG.myapikey@smtp.sendgrid.net:465 | `string` | n/a | yes |
@@ -57,6 +55,7 @@ No modules.
 | <a name="input_project"></a> [project](#input\_project) | Project name to used as label and prefix for created resources | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of main Kratos pod replicas, must be a positive integer | `number` | `1` | no |
 | <a name="input_resources"></a> [resources](#input\_resources) | Resource requests and limits for main Kratos pods | <pre>object({<br/>    requests = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>    limits = object({<br/>      cpu    = string<br/>      memory = string<br/>    })<br/>  })</pre> | n/a | yes |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | External secrets to import and use instead of generating new ones, cookie must be at least 16 characters long and cipher must be exactly 32 characters long | <pre>object({<br/>    cookie = string<br/>    cipher = string<br/>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/kratos/kratos.tf
+++ b/kratos/kratos.tf
@@ -1,5 +1,5 @@
 resource "random_password" "kratos_cookie_secret" {
-  count = var.cookie_secret == null ? 1 : 0
+  count = var.secrets == null ? 1 : 0
 
   length  = 64
   special = false
@@ -11,7 +11,7 @@ moved {
 }
 
 resource "random_password" "kratos_cipher_secret" {
-  count = var.cipher_secret == null ? 1 : 0
+  count = var.secrets == null ? 1 : 0
 
   length  = 32
   special = false
@@ -448,8 +448,8 @@ resource "kubernetes_ingress_v1" "kratos_ingress" {
 }
 
 locals {
-  cookie_secret = try(random_password.kratos_cookie_secret[0].result, var.cookie_secret)
-  cipher_secret = try(random_password.kratos_cipher_secret[0].result, var.cipher_secret)
+  cookie_secret = try(random_password.kratos_cookie_secret[0].result, var.secrets.cookie)
+  cipher_secret = try(random_password.kratos_cipher_secret[0].result, var.secrets.cipher)
 
   service_url = "http://${kubernetes_service_v1.kratos_service.metadata[0].name}.${kubernetes_service_v1.kratos_service.metadata[0].namespace}.svc.cluster.local"
 }

--- a/kratos/variables.tf
+++ b/kratos/variables.tf
@@ -121,29 +121,24 @@ variable "courier_smtp_connection_uri" {
   nullable    = false
 }
 
-variable "cookie_secret" {
-  type        = string
-  description = "External cookie secret to import and use instead of generating one, must be at least 16 characters long"
+variable "secrets" {
+  type = object({
+    cookie = string
+    cipher = string
+  })
+  description = "External secrets to import and use instead of generating new ones, cookie must be at least 16 characters long and cipher must be exactly 32 characters long"
   sensitive   = true
   nullable    = true
   default     = null
 
   validation {
-    condition     = var.cookie_secret == null || length(var.cookie_secret) >= 16
-    error_message = "The value of cookie_secret must be at least 16 characters long."
+    condition     = var.secrets == null || length(var.secrets.cookie) >= 16
+    error_message = "The value of cookie secret must be at least 16 characters long."
   }
-}
-
-variable "cipher_secret" {
-  type        = string
-  description = "External cipher secret to import and use instead of generating one, must be exactly 32 characters long"
-  sensitive   = true
-  nullable    = true
-  default     = null
 
   validation {
-    condition     = var.cipher_secret == null || length(var.cipher_secret) == 32
-    error_message = "The value of cipher_secret must be exactly 32 characters long."
+    condition     = var.secrets == null || length(var.secrets.cipher) == 32
+    error_message = "The value of cipher secret must be exactly 32 characters long."
   }
 }
 


### PR DESCRIPTION
Addresses an issue where Terraform is unable to statically determine if new secrets should be created or not during the planning phase (because they are chained from the output of another instance of this module).