### PR TITLE
Fix terraform validation error in variables.tf

### DIFF
--- a/kratos/variables.tf
+++ b/kratos/variables.tf
@@ -131,13 +131,14 @@ variable "secrets" {
   nullable    = true
   default     = null
 
+  # Wrapping expressions in "try" functions to satisfy terrafom validation
   validation {
-    condition     = var.secrets == null || length(var.secrets.cookie) >= 16
+    condition     = var.secrets == null || try(length(var.secrets.cookie), 0) >= 16
     error_message = "The value of cookie secret must be at least 16 characters long."
   }
 
   validation {
-    condition     = var.secrets == null || length(var.secrets.cipher) == 32
+    condition     = var.secrets == null || try(length(var.secrets.cipher), 0) == 32
     error_message = "The value of cipher secret must be exactly 32 characters long."
   }
 }

--- a/kratos/variables.tf
+++ b/kratos/variables.tf
@@ -131,7 +131,7 @@ variable "secrets" {
   nullable    = true
   default     = null
 
-  # Wrapping expressions in "try" functions to satisfy terrafom validation
+  # Wrapping expressions in "try" functions to satisfy terraform validation
   validation {
     condition     = var.secrets == null || try(length(var.secrets.cookie), 0) >= 16
     error_message = "The value of cookie secret must be at least 16 characters long."


### PR DESCRIPTION
During its validation phase, Terraform attempts to parse and understand all possible paths and dependencies in the dependency graph. It sees that there is an attempt to access, e.g. `var.secrets.cookie`. Before it even gets to the conditional logic of outer condition, it tries to validate the existence of this attribute path. This resulted in:
```
│ Error: Attempt to get attribute from null value
│ 
│   on .terraform/modules/kratos/kratos/variables.tf line 140, in variable "secrets":
│  140:     condition     = !can(var.secrets.cipher) || length(var.secrets.cipher) >= 32
│     ├────────────────
│     │ var.secrets is null
│ 
│ This value is null, so it does not have any attributes.
```